### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A Model Context Protocol (MCP) server that provides access to the Metropolitan M
 - [License](#license)
 - [Disclaimer](#disclaimer)
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mikechao-metmuseum-mcp).
+
 ## Features
 
 This server provides AI models the following tools to interact with the art collection of The Met:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mikechao-metmuseum-mcp)