### PR TITLE
Dockerfile build fails due to missing eslint config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN corepack enable && pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy TypeScript configuration and source code
 COPY tsconfig.json ./
+COPY eslint.config.mjs ./
 COPY src ./src
 COPY scripts ./scripts
 


### PR DESCRIPTION
The prebuild hook in package.json runs `lint:check` (`eslint . --ext .ts,.js,.mjs,.cjs`), but the Dockerfile doesn't copy eslint.config.mjs into the build context. This causes the build to fail with:

```
ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
```

Adding the missing COPY fixes the build.